### PR TITLE
Add dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+version: 2
+updates:
+- package-ecosystem: maven
+  directory: "/"
+  schedule:
+    interval: weekly
+  open-pull-requests-limit: 10
+  target-branch: master
+  reviewers:
+  - MarkEWaite
+  labels:
+  - dependencies
+  ignore:
+  # the dependency is actually provided by the Web container, hence it is aligned with Jetty. See https://github.com/jenkinsci/jenkins/pull/5211
+  - dependency-name: "javax.servlet:javax.servlet-api"


### PR DESCRIPTION
I have added the dependabot configuration from the [pipeline-steps-doc-generator](https://github.com/jenkins-infra/pipeline-steps-doc-generator/blob/master/.github/dependabot.yml) repository here so as to keep the dependencies updated here as well.