### PR TITLE
Fix: Javadoc errors

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -30,7 +30,7 @@ pipeline {
     stages {
         stage("build") {
             steps {
-                sh 'mvn clean validate -Dmaven.test.failure.ignore=true'
+                sh 'mvn clean validate javadoc:aggregate -Dmaven.test.failure.ignore=true'
             }
         }
     }

--- a/src/main/java/hudson/MockJenkins.java
+++ b/src/main/java/hudson/MockJenkins.java
@@ -39,10 +39,10 @@ public class MockJenkins {
 
     /**
      * There are a few methods that need to be mocked in order for setup to work properly:
-     *     * getPluginManager -> must return HyperLocalPluginManager
-     *     * getInitLevel     -> COMPLETED; Jenkins is "setup" as soon as the pm is populated
-     *     * getExtensionList -> use the MockExtensionLists
-     *     * getPlugin        -> get the Plugin information from HyperLocalPluginManager
+     *     * getPluginManager -&gt; must return HyperLocalPluginManager
+     *     * getInitLevel     -&gt; COMPLETED; Jenkins is "setup" as soon as the pm is populated
+     *     * getExtensionList -&gt; use the MockExtensionLists
+     *     * getPlugin        -&gt; get the Plugin information from HyperLocalPluginManager
      */
      @SuppressWarnings({"unchecked", "rawtypes"})
      public Jenkins getMockJenkins(HyperLocalPluginManager pm) {

--- a/src/main/java/org/jenkinsci/infra/tools/HyperLocalPluginManager.java
+++ b/src/main/java/org/jenkinsci/infra/tools/HyperLocalPluginManager.java
@@ -403,11 +403,11 @@ public class HyperLocalPluginManager extends LocalPluginManager{
      * This is pretty much a copy of the final ExtensionFinder.Sezpoz class from 1.651 fitted
      * for a custom ClassLoader rather than checking Jenkins
      * The only differences are:
-     *   * getIndices -> ClassLoader parameter; doesn't check Jenkins
-     *   * find -> ClassLoader parameter
-     *   * scout -> ClassLoader parmeter
+     *   * getIndices -&gt; ClassLoader parameter; doesn't check Jenkins
+     *   * find -&gt; ClassLoader parameter
+     *   * scout -&gt; ClassLoader parmeter
      *
-     * IMPORTANT: don't use find(Class<T> type, Hudson hud) as the getIndices method will error.
+     * IMPORTANT: don't use find(Class&lt;T&gt; type, Hudson hud) as the getIndices method will error.
      */
     public static final class SmallSezpoz extends ExtensionFinder {
 


### PR DESCRIPTION
Escaped `<` and `>` as `&lt;` and `&gt;` respectively.

- [x] `mvn javadoc:aggregate` running without any errors now.