### PR TITLE
Fix method to get plugin name

### DIFF
--- a/src/main/java/org/jenkinsci/infra/tools/HyperLocalPluginManager.java
+++ b/src/main/java/org/jenkinsci/infra/tools/HyperLocalPluginManager.java
@@ -529,7 +529,6 @@ public class HyperLocalPluginManager extends LocalPluginManager {
      */
     public String getPluginNameForDescriptor(Descriptor<?> d) {
         String className = d.getClass().getName();
-        String pluginName = uberPlusClassLoader.getByPlugin().get(className);
         // try one last time to find out which plugin this belongs to (needed for
         // WEBSITE-434)
         try {
@@ -537,6 +536,7 @@ public class HyperLocalPluginManager extends LocalPluginManager {
         } catch (ClassNotFoundException e) {
             LOG.log(Level.FINER, "Class not found for " + d.getId());
         }
+        String pluginName = uberPlusClassLoader.getByPlugin().get(className);
         if (pluginName == null) {
             LOG.info("No plugin found, assuming core: " + className);
             return "core";


### PR DESCRIPTION
Relates to https://github.com/jenkins-infra/jenkins.io/issues/5336

Seems like the only change was the assigning of the plugin name, which now is restored to the version that gave correct results. This should hopefully fix the error mention in the issue.

@jmMeessen can you create a release it after merge so that we can test if everything works fine now?

