### PR TITLE
Use `bom-weekly`

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
     <dependencies>
       <dependency>
         <groupId>io.jenkins.tools.bom</groupId>
-        <artifactId>bom-2.319.x</artifactId>
+        <artifactId>bom-weekly</artifactId>
         <version>1607.va_c1576527071</version>
         <type>pom</type>
         <scope>import</scope>


### PR DESCRIPTION
Consistent with https://github.com/jenkins-infra/pipeline-steps-doc-generator/blob/master/pom.xml#L70 and makes sense logically because the `jenkins-core` dependency is tracking the weekly release per https://github.com/jenkinsci/bom#depending-on-bom-weekly.