### PR TITLE
Bump parent POM from 1.87 to 1.88

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,6 @@
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-inline</artifactId>
-      <version>4.7.0</version>
   </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.jenkins-ci</groupId>
     <artifactId>jenkins</artifactId>
-    <version>1.87</version>
+    <version>1.88</version>
     <relativePath />
   </parent>
 
@@ -43,7 +43,6 @@
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
-      <version>4.7.0</version>
     </dependency>
     <dependency>
       <groupId>org.mockito</groupId>


### PR DESCRIPTION
Upgrade the parent POM from 1.87 to 1.88. Version 1.88 includes a managed Mockito dependency, so we no longer need to manage the Mockito version in this repository. This should result in fewer Dependabot PRs by consolidating the Mockito version in the parent POM.