### PR TITLE
chore: pin GitHub actions with their SHA-1 instead of their version number

### DIFF
--- a/.github/workflows/jenkins-security-scans.yml
+++ b/.github/workflows/jenkins-security-scans.yml
@@ -8,7 +8,7 @@ on:
   workflow_dispatch:
 jobs:
   security-scan:
-    uses: jenkins-infra/jenkins-security-scan/.github/workflows/jenkins-security-scan.yaml@c3913481f441b1098da4ed71363ecce69986bb0c # ratchet:jenkins-infra/jenkins-security-scan/.github/workflows/jenkins-security-scan.yaml@v2
+    uses: jenkins-infra/jenkins-security-scan/.github/workflows/jenkins-security-scan.yaml@v2
     with:
       java-cache: 'maven'
       java-version: 11

--- a/.github/workflows/jenkins-security-scans.yml
+++ b/.github/workflows/jenkins-security-scans.yml
@@ -4,12 +4,11 @@ on:
     branches:
       - master
   pull_request:
-    types: [ opened, synchronize, reopened ]
+    types: [opened, synchronize, reopened]
   workflow_dispatch:
-
 jobs:
   security-scan:
-    uses: jenkins-infra/jenkins-security-scan/.github/workflows/jenkins-security-scan.yaml@v2
+    uses: jenkins-infra/jenkins-security-scan/.github/workflows/jenkins-security-scan.yaml@c3913481f441b1098da4ed71363ecce69986bb0c # ratchet:jenkins-infra/jenkins-security-scan/.github/workflows/jenkins-security-scan.yaml@v2
     with:
       java-cache: 'maven'
       java-version: 11

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -7,6 +7,6 @@ jobs:
   update_release_draft:
     runs-on: ubuntu-latest
     steps:
-      - uses: release-drafter/release-drafter@v5.23.0
+      - uses: release-drafter/release-drafter@569eb7ee3a85817ab916c8f8ff03a5bd96c9c83e # v5.23.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Ref: https://github.com/jenkins-infra/helpdesk/issues/3402