### PR TITLE
Use jsoup API plugin instead of jsoup jar file

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -51,6 +51,11 @@
       <version>1.3.5</version>
     </dependency>
     <dependency>
+      <groupId>jakarta.servlet</groupId>
+      <artifactId>jakarta.servlet-api</artifactId>
+      <version>5.0.0</version>
+    </dependency>
+    <dependency>
       <groupId>javax.servlet</groupId>
       <artifactId>javax.servlet-api</artifactId>
       <version>3.1.0</version>
@@ -62,16 +67,15 @@
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>jsoup</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>structs</artifactId>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins.workflow</groupId>
       <artifactId>workflow-step-api</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.jsoup</groupId>
-      <artifactId>jsoup</artifactId>
-      <version>1.19.1</version>
     </dependency>
     <dependency>
       <groupId>org.mockito</groupId>


### PR DESCRIPTION
## Use jsoup API plugin instead of jsoup jar file

Dependency checking for the API plugins is handled by the plugin BOM that is already being used in this repository.  Benefit from testing that is done by plugin BOM and use a configuration that is the preferred configuration for Jenkins controllers.

Includes servlet-api 5.0.0 to satisfy the dependency on Jakarta EE 9.
