### PR TITLE
Use CODEOWNERS instead of dependabot reviewers

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @jenkins-infra/core

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,8 +6,6 @@ updates:
     interval: weekly
   open-pull-requests-limit: 10
   target-branch: master
-  reviewers:
-  - MarkEWaite
   labels:
   - dependencies
   ignore:


### PR DESCRIPTION
## Use CODEOWNERS instead of dependabot reviewers

Dependabot is now posting this comment as a warning:

The reviewers field in the dependabot.yml file will be removed soon. Please use the code owners file to specify reviewers for Dependabot PRs. For more information, see this [blog post](https://github.blog/changelog/2025-04-29-dependabot-reviewers-configuration-option-being-replaced-by-code-owners/).

Resolve that warning by replacing the reviewers entry in dependabot with a CODEOWNERS file.
