### PR TITLE
Use same ci.jenkins.io label as pipeline steps doc generator

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -6,7 +6,7 @@ pipeline {
     }
 
     agent {
-        label "java"
+        label "linux-amd64"
     }
 
     // Make sure we have GIT_COMMITTER_NAME and GIT_COMMITTER_EMAIL set due to machine weirdness.


### PR DESCRIPTION
## Use same ci.jenkins.io label as pipeline steps doc generator

The label 'java' is not satisfied on ci.jenkins.io.
