### PR TITLE
Use container agent for ci.jenkins.io

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -6,7 +6,7 @@ pipeline {
     }
 
     agent {
-        label "linux-amd64"
+        label "maven-21"
     }
 
     // Make sure we have GIT_COMMITTER_NAME and GIT_COMMITTER_EMAIL set due to machine weirdness.


### PR DESCRIPTION
## Use container agent for ci.jenkins.io

Don't need the power of a virtual machine and don't need the setup time required to start a virtual machine.
